### PR TITLE
`script/generate delayed_job_migration` didn't work for me

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -16,7 +16,7 @@ h2. Setup
 
 The library evolves around a delayed_jobs table which can be created by using:
 <pre><code>
-  script/generate delayed_job_migration
+  script/generate delayed_job
 </code></pre>
 
 The created table looks as follows: 


### PR DESCRIPTION
This did.  Tested only on Ruby 1.8.7 and Rails 2.3.5.  -Dan
