### PR TITLE
enable send_later for module methods

### DIFF
--- a/lib/delayed/performable_method.rb
+++ b/lib/delayed/performable_method.rb
@@ -38,7 +38,7 @@ module Delayed
 
     def dump(arg)
       case arg
-      when Class              then class_to_string(arg)
+      when Class, Module      then class_to_string(arg)
       when ActiveRecord::Base then ar_to_string(arg)
       else arg
       end

--- a/spec/delayed_method_spec.rb
+++ b/spec/delayed_method_spec.rb
@@ -11,6 +11,12 @@ class RandomRubyObject
   end
 end
 
+module RandomModule
+  def self.say_hello
+    'hello'
+  end
+end
+
 class ErrorObject
 
   def throw
@@ -110,6 +116,14 @@ describe 'random ruby objects' do
     job.payload_object.perform.should == 'Epilog: Once upon...'
   end                 
   
+  it "should store the object as string if it's a module" do
+    RandomModule.send_later(:say_hello)
+    job = Delayed::Job.find(:first)
+    job.payload_object.method.should  == :say_hello
+    job.payload_object.object.should  == "CLASS:RandomModule"
+    job.payload_object.perform.should == 'hello'
+  end
+
   it "should call send later on methods which are wrapped with handle_asynchronously" do
     story = Story.create :text => 'Once upon...'
   


### PR DESCRIPTION
I made a patch to enable send_later not only for class methods but for module methods as well. There's [an issue](https://github.com/tobi/delayed_job/issues/19) for that already, but it didn't get fixed yet.
