### PR TITLE
fix README: configs are cattrs on Delayed::Worker

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -44,17 +44,15 @@ The default @MAX_RUN_TIME@ is @4.hours@. If your job takes longer than that, ano
 make sure your job doesn't exceed this time. You should set this to the longest time you think the job could take.
 
 By default, it will delete failed jobs (and it always deletes successful jobs). If you want to keep failed jobs, set
-@Delayed::Job.destroy_failed_jobs = false@. The failed jobs will be marked with non-null failed_at.
+@Delayed::Worker.destroy_failed_jobs = false@. The failed jobs will be marked with non-null failed_at.
 
 Here is an example of changing job parameters in Rails:
 
 <pre><code>
   # config/initializers/delayed_job_config.rb
-  Delayed::Job.destroy_failed_jobs = false
-  silence_warnings do
-    Delayed::Job.const_set("MAX_ATTEMPTS", 3)
-    Delayed::Job.const_set("MAX_RUN_TIME", 5.minutes)
-  end
+  Delayed::Worker.destroy_failed_jobs = false
+  Delayed::Worker.max_attempts = 3
+  Delayed::Worker.max_run_time = 5.minutes
 </code></pre>
 
 Note: If your error messages are long, consider changing last_error field to a :text instead of a :string (255 character limit).


### PR DESCRIPTION
Hello, tobi.

Thanks for maintaining delayed_job.  It's awesome.

I noticed that the initializer example seems to have become wrong.

Here's a fix.

Best,
bonkydog
