### PR TITLE
A note guiding the reader to the gem's repo (tobi/delayed_job is the firs

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -1,3 +1,5 @@
+'''note''': this is not the repository for the '''delayed_job''' gem from rubygems.org. That repo is here: https://github.com/collectiveidea/delayed_job/
+
 h1. Delayed::Job
 
 Delayed_job (or DJ) encapsulates the common pattern of asynchronously executing longer tasks in the background. 


### PR DESCRIPTION
A note guiding the reader to the gem's repo (tobi/delayed_job is the first hit on google)
