### PR TITLE
warning due to bad paths in gemspec file

### DIFF
--- a/delayed_job.gemspec
+++ b/delayed_job.gemspec
@@ -31,8 +31,8 @@ Gem::Specification.new do |s|
     lib/delayed/performable_method.rb
     lib/delayed/worker.rb
     lib/delayed_job.rb
-    tasks/jobs.rake
-    tasks/tasks.rb
+    lib/tasks/jobs.rake
+    lib/tasks/tasks.rb
   ]
   s.test_files = %w[
     spec/database.rb


### PR DESCRIPTION
delayed_job at /Users/subbarao/.rbenv/versions/1.9.3-p0/lib/ruby/gems/1.9.1/bundler/gems/delayed_job-719b628bdd54 did not have a valid gemspec.
This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
The validation message from Rubygems was:
  ["tasks/jobs.rake", "tasks/tasks.rb"] are not files
