### PR TITLE
set_table_name has been deprecated in favor of self.table_name= as of Rails 3.2

### DIFF
--- a/lib/delayed/job.rb
+++ b/lib/delayed/job.rb
@@ -8,7 +8,7 @@ module Delayed
   class Job < ActiveRecord::Base
     MAX_ATTEMPTS = 25
     MAX_RUN_TIME = 4.hours
-    set_table_name :delayed_jobs
+    self.table_name = :delayed_jobs
 
     # By default failed jobs are destroyed after too many attempts.
     # If you want to keep them around (perhaps to inspect the reason


### PR DESCRIPTION
See https://github.com/rails/rails/commit/0b72a04
