### PR TITLE
Incorrect code example removed

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -99,15 +99,7 @@ You can also run by writing a simple @script/job_runner@, and invoking it extern
 </code></pre>
 
 Workers can be running on any computer, as long as they have access to the database and their clock is in sync. You can even
-run multiple workers on per computer, but you must give each one a unique name:
-
-<pre><code>
-  3.times do |n|
-    worker = Delayed::Worker.new
-    worker.name = 'worker-' + n.to_s
-    worker.start
-  end	
-</code></pre>
+run multiple workers on per computer, but you must give each one a unique name.
 
 Keep in mind that each worker will check the database at least every 5 seconds.
 


### PR DESCRIPTION
See comment on issue #43.  
This actually does not work. The first worker will block the next until it receives a kill (TERM or INT) and then the next one starts. This is not multiple works but running three one after the other. Please remove this incorrect documentation as it will cause people to waste time trying it.
